### PR TITLE
Summit config: use modules for compilers and mpi

### DIFF
--- a/spack/configs/summit/compilers.yaml
+++ b/spack/configs/summit/compilers.yaml
@@ -24,6 +24,18 @@ compilers:
     flags: {}
     operating_system: rhel7
     target: ppc64le
-    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@19.9
+    modules: [pgi/19.9]
+    paths:
+      cc: /autofs/nccs-svm1_sw/summit/.swci/0-core/opt/spack/20180914/linux-rhel7-ppc64le/gcc-4.8.5/pgi-19.9-6rlh73dtf3lmbm6v7r3fkh7tnbeq53hc/linuxpower/19.9/bin/pgcc
+      cxx: /autofs/nccs-svm1_sw/summit/.swci/0-core/opt/spack/20180914/linux-rhel7-ppc64le/gcc-4.8.5/pgi-19.9-6rlh73dtf3lmbm6v7r3fkh7tnbeq53hc/linuxpower/19.9/bin/pgc++
+      f77: /autofs/nccs-svm1_sw/summit/.swci/0-core/opt/spack/20180914/linux-rhel7-ppc64le/gcc-4.8.5/pgi-19.9-6rlh73dtf3lmbm6v7r3fkh7tnbeq53hc/linuxpower/19.9/bin/pgfortran
+      fc: /autofs/nccs-svm1_sw/summit/.swci/0-core/opt/spack/20180914/linux-rhel7-ppc64le/gcc-4.8.5/pgi-19.9-6rlh73dtf3lmbm6v7r3fkh7tnbeq53hc/linuxpower/19.9/bin/pgfortran
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
     environment: {}
     extra_rpaths: []

--- a/spack/configs/summit/packages.yaml
+++ b/spack/configs/summit/packages.yaml
@@ -9,9 +9,9 @@ packages:
   # system modules externals. Uses explicit paths rather than the modules
   # feature of spack, more robust and simpler in some cases.
   spectrum-mpi:
-    paths:
-      spectrum-mpi@10.3.1.2-20200121%gcc@8.1.1: /sw/summit/.swci/1-compute/opt/spack/20180914/linux-rhel7-ppc64le/gcc-8.1.1/spectrum-mpi-10.3.1.2-20200121-chae23sgwacfeot7vxkpfboz6wao2c33
-      spectrum-mpi@10.3.1.2-20200121%pgi@19.9: /sw/summit/.swci/1-compute/opt/spack/20180914/linux-rhel7-ppc64le/pgi-19.9/spectrum-mpi-10.3.1.2-20200121-zy6l7p3w4q2ns7i2zutzng7ex3drw656
+    modules:
+      spectrum-mpi@10.3.1.2-20200121%gcc@8.1.1: spectrum-mpi/10.3.1.2-20200121
+      spectrum-mpi@10.3.1.2-20200121%pgi@19.9: spectrum-mpi/10.3.1.2-20200121
     buildable: false
 
   fftw:


### PR DESCRIPTION
Spack does not clean the environment enough on Summit to use hard coded paths for the compilers and mpi when default modules are loaded in the shell (xl and spectrum-mpi built with xl).  An alternative is to ask users to purge their modules (or at least some of them) before using our spack packages.  To avoid this step, and possible problems/errors associated with it, I propose we use modules instead of paths on Summit for compilers and mpi.  For other libraries, I don't think using the system modules is critical as they are less likely to make significant changes to the environment.

With this PR, I am able to build xgc1 on summit using gcc/8.1.1 and Spectrum-MPI.  The gene install just ~~started~~ completed successfully.

For the record, my build process was:

```console
git clone git@github.com:SCOREC/wdmapp-config
cd wdmapp-config
git checkout cws/use_modules
# BACKUP YOUR SETTINGS BEFORE RUNNING THE FOLLOWING CMD 
cp wdmapp-config/spack/configs/summit/*.yaml ~/.spack/linux/ 
cd -
git clone git@github.com:spack/spack.git
cd spack
git checkout v0.14.0
source share/spack/setup-env.sh # setup spack env
spack install xgc1+coupling_core_edge+coupling_core_edge_field+coupling_core_edge_varpi2
spack install gene
```