### PR TITLE
wdmapp spack package

### DIFF
--- a/spack/wdmapp/packages/gene/package.py
+++ b/spack/wdmapp/packages/gene/package.py
@@ -20,9 +20,6 @@ class Gene(CMakePackage, CudaPackage):
     version('cuda_under_the_hood',
             branch='cuda_under_the_hood',
             submodules=True, submodules_delete=['python-diag'])
-    version('cuth-wip', git='git@github.com:wdmapp/gene-wip.git',
-            branch='cuth-wip',
-            submodules=True, submodules_delete=['python-diag'])
 
     variant('pfunit', default=True,
             description='Enable pfunit tests')

--- a/spack/wdmapp/packages/gene/package.py
+++ b/spack/wdmapp/packages/gene/package.py
@@ -12,13 +12,15 @@ class Gene(CMakePackage, CudaPackage):
     homepage = "http://genecode.org"
     # FIXME, there is no tarball, but it still needs a URL, so it's fake
     url      = "https://github.com/wdmapp/gene-wip.tar.gz"
-    git      = "git@gitlab.mpcdf.mpg.de:GENE/gene-dev.git"
+    git      = 'git@github.com:wdmapp/gene.git'
 
     maintainers = ['germasch', 'bd4']
 
     # FIXME: Add proper versions and checksums here.
-    version('cuda_under_the_hood',
-            branch='cuda_under_the_hood',
+    version('cuda_under_the_hood', git="git@gitlab.mpcdf.mpg.de:GENE/gene-dev.git",
+            branch='cuda_under_the_hood', preferred=True,
+            submodules=True, submodules_delete=['python-diag'])
+    version('coupling', branch='coupling',
             submodules=True, submodules_delete=['python-diag'])
 
     variant('pfunit', default=True,
@@ -28,6 +30,16 @@ class Gene(CMakePackage, CudaPackage):
     variant('perf', default='none', multi=False,
             description='Enable performance library for timing code regions',
             values=('perfstubs', 'nvtx', 'ht', 'none'))
+    variant('adios2', default=False,
+            description='Enable ADIOS2 I/O capabilities')
+    variant('futils', default=False,
+            description='Enable futils capabilities')
+    variant('read_xgc', default=False,
+            description='Enable reading of XGC files')
+    variant('diag_planes', default=False,
+            description='Enable diag_planes')
+    variant('couple_xgc', default=False,
+            description='Enable coupling with XGC')
 
     depends_on('mpi')
     depends_on('fftw@3.3:')
@@ -35,10 +47,17 @@ class Gene(CMakePackage, CudaPackage):
     depends_on('scalapack')
     depends_on('mpi')
     depends_on('pfunit@3.3.3:3.3.99+mpi max_array_rank=6', when='+pfunit')
+    depends_on('adios2', when='+adios2')
+    depends_on('hdf5+fortran', when='+futils')
 
     def cmake_args(self):
         spec = self.spec
         args = ['-DGENE_PERF={0}'.format(spec.variants['perf'].value)]
+        args += ['-DGENE_USE_ADIOS2={}'.format('ON' if '+adios2' in spec else 'OFF')]
+        args += ['-DGENE_USE_FUTILS={}'.format('ON' if '+futils' in spec else 'OFF')]
+        args += ['-DGENE_READ_XGC={}'.format('ON' if '+read_xgc' in spec else 'OFF')]
+        args += ['-DGENE_DIAG_PLANES={}'.format('ON' if '+diag_planes' in spec else 'OFF')]
+        args += ['-DGENE_COUPLE_XGC={}'.format('ON' if '+couple_xgc' in spec else 'OFF')]
         if '+pfunit' in spec:
             args.append('-DPFUNIT={}'.format(spec['pfunit'].prefix))
         if '+cuda' in spec:

--- a/spack/wdmapp/packages/perfstubs/package.py
+++ b/spack/wdmapp/packages/perfstubs/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Perfstubs(CMakePackage):
+    """Profiling API for adding tool instrumentation support to any project.
+
+    This was motivated by the need to quickly add instrumentation to the
+    [ADIOS2](https://github.com/ornladios/ADIOS2) library without adding a build
+    dependency, or tying to a specific measurement tool.
+
+    The initial prototype implementation was tied to TAU, but evolved to this more
+    generic version, which was extracted as a separate repository for testing and
+    demonstration purposes.
+    """
+
+    homepage = "https://github.com/khuck/perfstubs"
+    git      = "https://github.com/khuck/perfstubs.git"
+
+    version('master', branch='master')
+    variant('static', default=False, description='Build static executable support')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DPERFSTUBS_USE_STATIC:BOOL={0}'.format(
+                'ON' if '+static' in spec else 'OFF')
+        ]
+        return args

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Wdmapp(BundlePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://github.com/wdmapp"
+    # There is no URL since there is no code to download.
+
+    maintainers = ['germasch', 'bd4']
+
+    version('0.0.1')
+
+    # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
+    depends_on('hdf5 +hl')
+    depends_on('gene@coupling +adios2 +futils +read_xgc +diag_planes +couple_xgc')
+    depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2')
+

--- a/spack/wdmapp/packages/xgc1/package.py
+++ b/spack/wdmapp/packages/xgc1/package.py
@@ -40,14 +40,8 @@ class Xgc1(CMakePackage):
         spec = self.spec
         args = []
         args += ['-DXGC_CAMTIMERS={}'.format('ON' if '+camtimers' in spec else 'OFF')]
-        if '+coupling_core_edge' in spec:
-            args.append('-DXGC_COUPLING_CORE_EDGE=ON')
-        if '+coupling_core_edge' in spec:
-            args.append('-DXGC_COUPLING_CORE_EDGE=ON')
-        if '+coupling_core_edge_field' in spec:
-            args.append('-DXGC_COUPLING_CORE_EDGE_FIELD=ON')
-        if '+coupling_core_edge_varpi2' in spec:
-            args.append('-DXGC_COUPLING_CORE_EDGE_VARPI2=ON')
-
+        args += ['-DXGC_COUPLING_CORE_EDGE={}'.format('ON' if '+coupling_core_edge' in spec else 'OFF')]
+        args += ['-DXGC_COUPLING_CORE_EDGE_FIELD={}'.format('ON' if '+coupling_core_edge_field' in spec else 'OFF')]
+        args += ['-DXGC_COUPLING_CORE_EDGE_VARPI2={}'.format('ON' if '+coupling_core_edge_varpi2' in spec else 'OFF')]
         return args
 

--- a/spack/wdmapp/packages/xgc1/package.py
+++ b/spack/wdmapp/packages/xgc1/package.py
@@ -19,6 +19,8 @@ class Xgc1(CMakePackage):
     version('master', branch='master')
     version('passThroughCpl', branch='cws/passThroughCpl')
 
+    variant('camtimers', default=True,
+            description='Enable camtimers')
     variant('coupling_core_edge', default=False,
             description='Enable XGC_COUPLING_CORE_EDGE')
     variant('coupling_core_edge_field', default=False,
@@ -30,13 +32,16 @@ class Xgc1(CMakePackage):
     depends_on('pkgconfig')
     #depends_on('parmetis')
     depends_on('pspline')
-    depends_on('camtimers')
+    depends_on('camtimers', when='+camtimers')
     depends_on('adios +fortran')
     depends_on('adios2 +fortran')
 
     def cmake_args(self):
         spec = self.spec
         args = []
+        args += ['-DXGC_CAMTIMERS={}'.format('ON' if '+camtimers' in spec else 'OFF')]
+        if '+coupling_core_edge' in spec:
+            args.append('-DXGC_COUPLING_CORE_EDGE=ON')
         if '+coupling_core_edge' in spec:
             args.append('-DXGC_COUPLING_CORE_EDGE=ON')
         if '+coupling_core_edge_field' in spec:


### PR DESCRIPTION
* update XGC1 package with camtimers variant
* update GENE for `coupling` branch and corresponding variants
* add a `wdmapp` meta-package that pulls in XGC1 and GENE in the configs needed for coupling

It's highly likely that the variants will go through some consolidation/cleanup later, but for now this gets everything into place for coupling new GENE and old XGC1.