### PR TITLE
Add XGC-Devel

### DIFF
--- a/spack/wdmapp/packages/kokkos/package.py
+++ b/spack/wdmapp/packages/kokkos/package.py
@@ -15,6 +15,8 @@ class Kokkos(Package):
     git      = "https://github.com/kokkos/kokkos.git"
 
     version('develop', branch='develop')
+    version('3.1.00', sha256='b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878')
+    version('3.0.00', sha256='c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b')
     version('2.9.00', sha256='e0621197791ed3a381b4f02c78fa529f3cff3abb74d52157b4add17e8aa04bc4')
     version('2.8.00', sha256='1c72661f2d770517bff98837001b42b9c677d1df29f7493a1d7c008549aff630')
     version('2.7.24', sha256='a308a80ea1488f4c18884b828ce7ae9f5210b9a6b2f61b208d875084d8da8cb0')

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -24,5 +24,6 @@ class Wdmapp(BundlePackage):
     depends_on('hdf5 +hl')
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes')
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2')
+    depends_on('xgc-devel@rpi +coupling_core_edge_gene')
     depends_on('coupler@master')
 

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+class XgcDevel(CMakePackage):
+    """XGC-Devel used for coupling with GENE-CUTH via the coupler"""
+
+    homepage = "https://hbps.pppl.gov/computing/xgc-1"
+    # FIXME, there is no tarball, but it still needs a URL, so it's fake
+    url      = "https://github.com/wdmapp/xgc1.tar.gz"
+    git      = "git@github.com:wdmapp/XGC-Devel.git"
+
+    maintainers = ['germasch', 'bd4', 'cwsmith', 'Damilare06']
+
+    version('rpi', branch='rpi')
+
+    variant('coupling_core_edge_gene', default=False,
+            description='Enable XGC_USE_GENE_COUPLING')
+
+    depends_on('petsc@3.7.0:3.7.999 ~complex +double')
+    depends_on('pkgconfig')
+    depends_on('adios +fortran')
+    depends_on('adios2 +fortran')
+    depends_on('fftw@3.3.8:')
+    depends_on('cabana@develop +openmp', when='@rpi')
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+        args += ['-DBUILD_TESTING=OFF']
+        args += ['-DXGC_USE_ADIOS1=ON']
+        args += ['-DXGC_USE_ADIOS2=ON']
+        args += ['-DXGC_USE_CABANA=ON']
+        args += ['-DXGC_USE_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
+        return args
+


### PR DESCRIPTION
This PR adds a package for the `rpi` branch of XGC-Devel.  

## Summary

There are three commits:
- `xgc-devel` package: https://github.com/wdmapp/wdmapp-config/commit/28470f0fc9317c58491633b855a4b5bb41b8b7d9 
- `kokkos` package update to list latest tagged versions: https://github.com/wdmapp/wdmapp-config/commit/51d348fe76d4f6f537dca55aabd2418de83ced10 . Spack PR https://github.com/spack/spack/pull/16354 .
- `wdmapp` package installs `xgc-devel@rpi` . https://github.com/wdmapp/wdmapp-config/commit/9accc0294e21b4daff3ed9fb1600ef669686ed1b

## XGC-Devel Notes
The `rpi` branch has a few commits to support the install via CMake:

- build with CMake without using machine specific include files:
https://github.com/wdmapp/XGC-Devel/commit/6fa9de106484526258a87dcdf776d2ae425a3937
https://github.com/wdmapp/XGC-Devel/commit/cfa6d816c1c012ca19eac88fe82fbe5999a80e17
- install executables:
https://github.com/wdmapp/XGC-Devel/commit/2eb964b7d48c96f15365140749137cd51bd6f6ac

The compile/preprocessor flags are not confirmed to be a correct/working subset towards running a coupled simulation with GENE-CUTH: https://github.com/wdmapp/XGC-Devel/blob/2eb964b7d48c96f15365140749137cd51bd6f6ac/CMakeLists.txt#L31-L41

## Testing

The `wdmapp` package was successfully installed on Summit after following the setup instructions here:
https://wdmapp.readthedocs.io/en/latest/machines/summit.html
