### PR TITLE
Some "wdmapp" spack package updates

### DIFF
--- a/docs/machines/longhorn.rst
+++ b/docs/machines/longhorn.rst
@@ -22,7 +22,7 @@ The following describes how to use the pre-installed openmpi 3.1.2 + gcc
 
 You can copy your choice of a basic or a more comprehensive setup for
 Spack on Longhorn from the
-`<https://github.com/wdmapp/wdmapp-config/longhorn/spack>`_ repository.
+`<https://github.com/wdmapp/wdmapp-config/tree/master/longhorn/spack>`_ repository.
  
 .. code-block:: sh
 

--- a/docs/machines/summit.rst
+++ b/docs/machines/summit.rst
@@ -13,7 +13,7 @@ Summit-Specific Setup
 
 You can copy your choice of a basic or a more comprehensive setup for
 Spack on Summit from the
-`<https://github.com/wdmapp/wdmapp-config/summit/spack>`_ repository.
+`<https://github.com/wdmapp/wdmapp-config/tree/master/summit/spack>`_ repository.
 
 .. code-block:: sh
 

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -22,7 +22,7 @@ class Wdmapp(BundlePackage):
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
     depends_on('hdf5 +hl')
-    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes')
+    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs')
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2')
     depends_on('xgc-devel@rpi +coupling_core_edge_gene')
     depends_on('coupler@master')

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -24,6 +24,6 @@ class Wdmapp(BundlePackage):
     depends_on('hdf5 +hl')
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs')
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2')
-    depends_on('xgc-devel@rpi +coupling_core_edge_gene')
+    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene')
     depends_on('coupler@master')
 


### PR DESCRIPTION
* make the "wdmapp" branch of XGC-Devel the branch to be used in the `wdmapp` bundle package
* use the "perfstubs" profiling option for GENE in the `wdmapp` bundle package
* also fix two links in the docs