### PR TITLE
wdmapp/xgc-devel updates for coupling

### DIFF
--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -27,6 +27,8 @@ class XgcDevel(CMakePackage):
     depends_on('adios2 +fortran')
     depends_on('fftw@3.3.8:')
     depends_on('cabana@develop')
+    depends_on('pspline')
+    depends_on('camtimers')
 
     def cmake_args(self):
         spec = self.spec
@@ -37,5 +39,7 @@ class XgcDevel(CMakePackage):
         args += ['-DXGC_USE_ADIOS2=ON']
         args += ['-DXGC_USE_CABANA=ON']
         args += ['-DXGC_USE_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
+        args += ['-DUSE_SYSTEM_PSPLINE=ON']
+        args += ['-DUSE_SYSTEM_CAMTIMERS=ON']
         return args
 

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -22,6 +22,8 @@ class XgcDevel(CMakePackage):
             description="use ADIOS2 for I/O")
     variant('coupling_core_edge_gene', default=False,
             description='Enable XGC_GENE_COUPLING')
+    variant('cabana', default=True,
+            description='Enable Kokkos/Cabana kernels')
 
     depends_on('petsc@3.7.0:3.7.999 ~complex +double')
     depends_on('pkgconfig')
@@ -29,18 +31,19 @@ class XgcDevel(CMakePackage):
     depends_on('adios2 +fortran', when='+adios2')
     depends_on('adios2 +fortran', when='+coupling_core_edge_gene')
     depends_on('fftw@3.3.8:')
-    depends_on('cabana@develop')
+    depends_on('cabana@develop', when='+cabana')
     depends_on('pspline')
     depends_on('camtimers')
 
     def cmake_args(self):
         spec = self.spec
         args = []
-        args += ['-DCMAKE_CXX_COMPILER=%s' % spec['kokkos'].kokkos_cxx]
         args += ['-DBUILD_TESTING=OFF']
         args += ['-DXGC_USE_ADIOS1=ON']
         args += ['-DXGC_USE_ADIOS2={}'.format('ON' if '+adios2' in spec else 'OFF')]
-        args += ['-DXGC_USE_CABANA=ON']
+        args += ['-DXGC_USE_CABANA={}'.format('ON' if '+cabana' in spec else 'OFF')]
+        if '+cabana' in spec:
+            args += ['-DCMAKE_CXX_COMPILER=%s' % spec['kokkos'].kokkos_cxx]
         args += ['-DXGC_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
         args += ['-DUSE_SYSTEM_PSPLINE=ON']
         args += ['-DUSE_SYSTEM_CAMTIMERS=ON']

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -18,13 +18,16 @@ class XgcDevel(CMakePackage):
     version('wdmapp', branch='wdmapp', preferred=True)
     version('rpi', branch='rpi')
 
+    variant('adios2', default=True,
+            description="use ADIOS2 for I/O")
     variant('coupling_core_edge_gene', default=False,
-            description='Enable XGC_USE_GENE_COUPLING')
+            description='Enable XGC_GENE_COUPLING')
 
     depends_on('petsc@3.7.0:3.7.999 ~complex +double')
     depends_on('pkgconfig')
     depends_on('adios +fortran')
-    depends_on('adios2 +fortran')
+    depends_on('adios2 +fortran', when='+adios2')
+    depends_on('adios2 +fortran', when='+coupling_core_edge_gene')
     depends_on('fftw@3.3.8:')
     depends_on('cabana@develop')
     depends_on('pspline')
@@ -36,9 +39,9 @@ class XgcDevel(CMakePackage):
         args += ['-DCMAKE_CXX_COMPILER=%s' % spec['kokkos'].kokkos_cxx]
         args += ['-DBUILD_TESTING=OFF']
         args += ['-DXGC_USE_ADIOS1=ON']
-        args += ['-DXGC_USE_ADIOS2=ON']
+        args += ['-DXGC_USE_ADIOS2={}'.format('ON' if '+adios2' in spec else 'OFF')]
         args += ['-DXGC_USE_CABANA=ON']
-        args += ['-DXGC_USE_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
+        args += ['-DXGC_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
         args += ['-DUSE_SYSTEM_PSPLINE=ON']
         args += ['-DUSE_SYSTEM_CAMTIMERS=ON']
         return args


### PR DESCRIPTION
With this and the latest `wdmapp` branch for XGC-Devel, we can actually run adios2-coupled runs now.