### PR TITLE
spack/summit: build RDMA-enabled libfabric / adios2

### DIFF
--- a/summit/spack/packages.yaml
+++ b/summit/spack/packages.yaml
@@ -19,6 +19,16 @@ packages:
       cuda@10.1.243: /sw/summit/cuda/10.1.243
     buildable: False
 
+  # build a libfabric that actually supports RDMA
+  libfabric:
+    variants: fabrics=sockets,tcp,udp,verbs,rxm
+
+  # use Summit-provided rdma-core
+  rdma-core:
+    paths:
+      rdma-core: /usr
+    buildable: False
+
   kokkos:
     variants: +cuda +openmp +volta70 +cuda_lambda +wrapper
     compiler: [gcc@8.1.1]


### PR DESCRIPTION
By default, spack's libfabric won't include RDMA support, and after enabling
it, the spack-built rdma-core interferes with what spectrum-mpi uses, so this
makes it use the system rdma-core.

Thanks to @philip-davis and @gmerlo.