### PR TITLE
add some variants to wdmapp metapackage

### DIFF
--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -20,10 +20,16 @@ class Wdmapp(BundlePackage):
 
     version('0.0.1')
 
+    variant('xgc1_legacy', default=False,
+            description='Build legacy XGC1/coupling code')
+
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
     depends_on('hdf5 +hl')
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs')
-    depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2')
     depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2')
     depends_on('coupler@master')
+
+    # variant +xgc1_legacy
+    depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2',
+               when='+xgc1_legacy')
 

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -22,6 +22,8 @@ class Wdmapp(BundlePackage):
 
     variant('xgc1_legacy', default=False,
             description='Build legacy XGC1/coupling code')
+    variant('tau', default=True,
+            description='Build TAU version needed for performance analysis of the coupled codes')
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
     depends_on('hdf5 +hl')
@@ -32,4 +34,7 @@ class Wdmapp(BundlePackage):
     # variant +xgc1_legacy
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2',
                when='+xgc1_legacy')
+
+    # variant +tau
+    depends_on('tau@develop +adios2 ~libunwind ~pdt +mpi', when='+tau')
 


### PR DESCRIPTION
This adds two variants to the package that make it possible to select whether legacy xgc1 and tau (which is added here) will be built.

I'm actually a bit torn as to whether adding variants is a good idea, so maybe this should be reconsidered at some point. Generally, variants make it harder to test / get all combinations to work right. In this case, though, all they do is enable or disable dependent packages, so they should be relatively harmless.

Mentioning @khuck so he knows that tau will now be included in the spec (optional, but on by default).