### PR TITLE
summit: system binutils has +libiberty +headers

### DIFF
--- a/summit/spack/packages-extended.yaml
+++ b/summit/spack/packages-extended.yaml
@@ -102,6 +102,7 @@ packages:
       pkg-config@0.27.1: /usr
 
   binutils:
+    variants: +libiberty +headers
     paths:
       binutils@2.27: /usr
 


### PR DESCRIPTION
Tau needs binutils with +libiberty and +headers to demangle symbols.