### PR TITLE
spack: use spectrum-mpi via modules on Summit

### DIFF
--- a/summit/spack/packages-extended.yaml
+++ b/summit/spack/packages-extended.yaml
@@ -19,9 +19,9 @@ packages:
   # system modules externals. Uses explicit paths rather than the modules
   # feature of spack, more robust and simpler in some cases.
   spectrum-mpi:
-    paths:
-      spectrum-mpi@10.3.1.2-20200121%gcc@8.1.1: /sw/summit/.swci/1-compute/opt/spack/20180914/linux-rhel7-ppc64le/gcc-8.1.1/spectrum-mpi-10.3.1.2-20200121-chae23sgwacfeot7vxkpfboz6wao2c33
-      spectrum-mpi@10.3.1.2-20200121%pgi@19.9: /sw/summit/.swci/1-compute/opt/spack/20180914/linux-rhel7-ppc64le/pgi-19.9/spectrum-mpi-10.3.1.2-20200121-zy6l7p3w4q2ns7i2zutzng7ex3drw656
+    modules:
+      spectrum-mpi@10.3.1.2-20200121%gcc@8.1.1: spectrum-mpi/10.3.1.2-20200121
+      spectrum-mpi@10.3.1.2-20200121%pgi@19.9: spectrum-mpi/10.3.1.2-20200121
     buildable: false
 
   fftw:


### PR DESCRIPTION
That makes `packages-extended.yaml` consistent with `packages.yaml` in
that aspect.

It also appears that it makes a real difference in that tau wasn't
working correctly with the paths method, though that has now been
updated in tau.