### PR TITLE
add effis and codar-cheetah packages from wdmapp/spack

### DIFF
--- a/spack/wdmapp/packages/codar-cheetah/package.py
+++ b/spack/wdmapp/packages/codar-cheetah/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class CodarCheetah(PythonPackage):
+    """CODAR Cheetah:
+    The CODAR Experiment Harness for Exascale science applications.
+    """
+
+    maintainers = ['kshitij-v-mehta']
+
+    homepage = "https://github.com/CODARcode/cheetah"
+    url      = "https://github.com/CODARcode/cheetah/archive/v0.1.tar.gz"
+    git      = "https://github.com/CODARcode/cheetah.git"
+
+    version('develop', branch='dev', preferred=True)
+    version('suchyta', git='https://github.com/suchyta1/cheetah.git', branch='dev')
+    version('0.5', sha256='f37a554741eff4bb8407a68f799dd042dfc4df525e84896cad70fccbd6aca6ee')
+    version('0.1', sha256='281564f8ae57a70ce28457616fde26247ea4efb29e55c7bf89a782a259a1a028')
+
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-setuptools')
+

--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -1,0 +1,54 @@
+from spack import *
+import os
+import sys
+import shutil
+
+
+class Effis(CMakePackage):
+    """Code Coupling framework"""
+
+    homepage = "https://github.com/wdmapp/effis"
+    url = homepage
+
+    version('effis',   git='https://github.com/wdmapp/effis.git', branch='effis',   preferred=True)
+    version('develop',   git='https://github.com/wdmapp/effis.git', branch='develop',   preferred=False)
+    version('login',   git='https://github.com/wdmapp/effis.git', branch='login',   preferred=False)
+    version('kittie',  git='https://github.com/wdmapp/effis.git', branch='kittie',  preferred=False)
+
+    variant("mpi", default=True, description="Use MPI")
+    variant("shared", default=True, description="Build shared library")
+
+    depends_on('mpi', when="+mpi")
+    depends_on('cmake')
+    depends_on('adios2')
+    depends_on('yaml-cpp')
+
+    extends('python')
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('py-setuptools')
+    depends_on('py-pyyaml')
+    depends_on('py-numpy')
+    depends_on('py-mpi4py', when="+mpi")
+
+    depends_on('codar-cheetah', when="^python@3:")
+    depends_on('py-matplotlib', when="^python@3:")
+
+
+    def cmake_args(self):
+        args = ['-DPYTHON_PREFIX=ON']
+
+        if not self.spec.satisfies('+mpi'):
+            args.append("-DUSE_MPI=OFF")
+        else:
+            args.append("-DCMAKE_CXX_COMPILER={0}".format(self.spec['mpi'].mpicxx))
+            args.append("-DCMAKE_C_COMPILER={0}".format(self.spec['mpi'].mpicc))
+            args.append("-DCMAKE_Fortran_COMPILER={0}".format(self.spec['mpi'].mpifc))
+
+        if self.spec.satisfies("+shared"):
+            args.append("-DBUILD_SHARED_LIBS:BOOL=ON")
+
+        if self.spec.satisfies("^adios2@:2.3.99"):
+            filter_file("OldStep = False", "OldStep = True", os.path.join(os.path.join('src', 'Python', 'kittie', 'kittie.py')))
+
+        return args
+


### PR DESCRIPTION
The codar-cheetah package is based on the spack 0.14.2 package with changes from wdmapp/spack. Effis is not in spack/spack.

@suchyta1 are there any other packages we will need to install effis with the `wdmapp` package?