### PR TITLE
support passthrough coupler: spack and instructions

### DIFF
--- a/spack/wdmapp/packages/coupler/package.py
+++ b/spack/wdmapp/packages/coupler/package.py
@@ -29,4 +29,5 @@ class Coupler(CMakePackage):
     def cmake_args(self):
         args = []
         args += ['-DCMAKE_CXX_COMPILER=%s' % self.spec['kokkos'].kokkos_cxx]
+        args += ['-DBUILD_TESTING=OFF']
         return args

--- a/spack/wdmapp/packages/gene/package.py
+++ b/spack/wdmapp/packages/gene/package.py
@@ -22,6 +22,8 @@ class Gene(CMakePackage, CudaPackage):
             submodules=True, submodules_delete=['python-diag'])
     version('coupling', branch='coupling',
             submodules=True, submodules_delete=['python-diag'])
+    version('passthrough', branch='rpi', git="git@github.com:Damilare06/gene.git",
+            submodules=True, submodules_delete=['python-diag'])
 
     variant('pfunit', default=True,
             description='Enable pfunit tests')

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -44,7 +44,7 @@ class Wdmapp(BundlePackage):
     depends_on('hdf5 +hl', when='+passthrough')
     depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+passthrough')
-    depends_on('xgc-devel@passthrough +coupling_core_edge_gene -cabana -adios2',
+    depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana -adios2',
         when='+passthrough')
     depends_on('coupler@develop',
         when='+passthrough')

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -18,7 +18,7 @@ class Wdmapp(BundlePackage):
 
     maintainers = ['germasch', 'bd4']
 
-    version('0.0.1',preferred=True)
+    version('0.0.1')
 
     variant('passthrough', default=False,
             description='Enable pass-through coupler')
@@ -30,14 +30,20 @@ class Wdmapp(BundlePackage):
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
     depends_on('hdf5 +hl')
     #normal
-    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs', when='~passthrough')
-    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2', when='~passthrough')
-    depends_on('coupler@master', when='~passthrough')
+    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
+        when='~passthrough')
+    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2',
+        when='~passthrough')
+    depends_on('coupler@master',
+        when='~passthrough')
 
     # variant +passthrough
-    depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs', when='+passthrough')
-    depends_on('xgc-devel@passthrough +coupling_core_edge_gene -cabana -adios2', when='+passthrough')
-    depends_on('coupler@develop', when='+passthrough')
+    depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
+        when='+passthrough')
+    depends_on('xgc-devel@passthrough +coupling_core_edge_gene -cabana -adios2',
+        when='+passthrough')
+    depends_on('coupler@develop',
+        when='+passthrough')
 
     # variant +xgc1_legacy
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2',

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -18,7 +18,7 @@ class Wdmapp(BundlePackage):
 
     maintainers = ['germasch', 'bd4']
 
-    version('0.0.1')
+    version('0.0.1',preferred=True)
 
     variant('passthrough', default=False,
             description='Enable pass-through coupler')
@@ -28,7 +28,10 @@ class Wdmapp(BundlePackage):
             description='Build TAU version needed for performance analysis of the coupled codes')
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
-    depends_on('hdf5 +hl')
+    # CWS - If the variant is not specified then there is a concretization error
+    # associated with hdf5.
+    # I think this is related to https://github.com/spack/spack/issues/15478 .
+    depends_on('hdf5 +hl', when='~passthrough')
     #normal
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='~passthrough')
@@ -38,6 +41,7 @@ class Wdmapp(BundlePackage):
         when='~passthrough')
 
     # variant +passthrough
+    depends_on('hdf5 +hl', when='+passthrough')
     depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+passthrough')
     depends_on('xgc-devel@passthrough +coupling_core_edge_gene -cabana -adios2',

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -18,8 +18,10 @@ class Wdmapp(BundlePackage):
 
     maintainers = ['germasch', 'bd4']
 
-    version('0.0.1')
+    version('0.0.1',preferred=True)
 
+    variant('passthrough', default=False,
+            description='Enable pass-through coupler')
     variant('xgc1_legacy', default=False,
             description='Build legacy XGC1/coupling code')
     variant('tau', default=True,
@@ -27,9 +29,15 @@ class Wdmapp(BundlePackage):
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
     depends_on('hdf5 +hl')
-    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs')
-    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2')
-    depends_on('coupler@master')
+    #normal
+    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs', when='~passthrough')
+    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2', when='~passthrough')
+    depends_on('coupler@master', when='~passthrough')
+
+    # variant +passthrough
+    depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs', when='+passthrough')
+    depends_on('xgc-devel@passthrough +coupling_core_edge_gene -cabana -adios2', when='+passthrough')
+    depends_on('coupler@develop', when='+passthrough')
 
     # variant +xgc1_legacy
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2',

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -17,6 +17,8 @@ class XgcDevel(CMakePackage):
 
     version('wdmapp', branch='wdmapp', preferred=True)
     version('rpi', branch='rpi')
+    version('passthrough', branch='passThrough',
+        git="git@github.com:Damilare06/XGC-Devel.git")
 
     variant('adios2', default=True,
             description="use ADIOS2 for I/O")

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -17,8 +17,6 @@ class XgcDevel(CMakePackage):
 
     version('wdmapp', branch='wdmapp', preferred=True)
     version('rpi', branch='rpi')
-    version('passthrough', branch='passThrough',
-        git="git@github.com:Damilare06/XGC-Devel.git")
 
     variant('adios2', default=True,
             description="use ADIOS2 for I/O")


### PR DESCRIPTION
This PR adds 
- support for installing the separate coupler and the associated branches of xgc and gene via spack, and 
- aimos developer install documentation.

One issue was hit in `wdmapp/package.py` that seems to be related to an existing spack concretization bug.  Specifically, if `depends_on('hdf5 +hl')` was not specified with the passthrough variant on and off then spack would fail to concretize the dependency in both cases.