### PR TITLE
wdmapp: add effis

### DIFF
--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -24,7 +24,7 @@ class Effis(CMakePackage):
     depends_on('yaml-cpp')
 
     # Needed for the installation process
-    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('python@2.7.12:', type=('build', 'run'))
     depends_on('py-setuptools')
 
     # These are not needed for non-Python application use of EFFIS

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -28,10 +28,11 @@ class Wdmapp(BundlePackage):
             description='Build TAU version needed for performance analysis of the coupled codes')
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
-    # CWS - If the variant is not specified then there is a concretization error
-    # associated with hdf5.
-    # I think this is related to https://github.com/spack/spack/issues/15478 .
+    # CWS - If the variant is not specified for hdf5 and effis then there are
+    # concretization errors associated with hdf5 and python. I think this is related 
+    # to https://github.com/spack/spack/issues/15478 .
     depends_on('hdf5 +hl', when='~passthrough')
+    depends_on('effis', when='~passthrough')
     #normal
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='~passthrough')
@@ -42,6 +43,7 @@ class Wdmapp(BundlePackage):
 
     # variant +passthrough
     depends_on('hdf5 +hl', when='+passthrough')
+    depends_on('effis', when='+passthrough')
     depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+passthrough')
     depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana -adios2',

--- a/summit/spack/packages-extended.yaml
+++ b/summit/spack/packages-extended.yaml
@@ -48,6 +48,7 @@ packages:
   python:
     paths:
       python@3.7.0anaconda: /sw/summit/python/3.7/anaconda3/5.3.0
+      python@2.7.15anaconda: /sw/summit/python/2.7/anaconda2/5.3.0
 
   cuda:
     paths:


### PR DESCRIPTION
effis requires python > 2.7.12 (another version > 2.7.5 may also work too) - see
https://github.com/wdmapp/effis/issues/2

The wdmapp meta package needed the same dirty hack that was used for hdf5; if the 'passthrough'
variant was not specified there were concretization errors.  Once we merge the
gene and xgc 'rpi' branches we can avoid the 'passthrough' (or similar) variants
that require divergent versions of packages.