### PR TITLE
spack: add config files for rhea

### DIFF
--- a/rhea/spack/compilers.yaml
+++ b/rhea/spack/compilers.yaml
@@ -1,0 +1,28 @@
+compilers:
+- compiler:
+    paths:
+      cc: /sw/rhea/gcc/8.4.0/bin/gcc
+      cxx: /sw/rhea/gcc/8.4.0/bin/g++
+      f77: /sw/rhea/gcc/8.4.0/bin/gfortran
+      fc: /sw/rhea/gcc/8.4.0/bin/gfortran
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      unset: []
+    extra_rpaths: []
+    flags: {}
+    spec: gcc@8.4.0
+- compiler:
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    spec: gcc@4.8.5

--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -1,0 +1,23 @@
+packages:
+
+  all:
+    compiler: [gcc@8.4.0]
+    providers:
+      mpi: [openmpi]
+      blas: [netlib-lapack]
+      lapack: [netlib-lapack]
+      scalapack: [netlib-scalapack]
+
+  slurm:
+    buildable: false
+    version: [19-05-0-1]
+    paths:
+      slurm@19-05-0-1: /usr
+
+  hwloc:
+    version: [1.11.11]
+
+  openmpi:
+    version: [3.1.4]
+    variants: "+pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm"
+


### PR DESCRIPTION
This supports building the `wdmapp` metapackage on rhea (works for me (tm), anyway ;) )

This has a rather minimal `package.yaml` which does not even use the system openmpi, but instead builds its own openmpi, using the same configuration as the system one.

The reason for this is that spack v.14 gets confused when trying to use the system openmpi, or other installed packages / modules on rhea, because those were installed by an older version of spack, which does provide some special information in a `.spack` directory, but not all that v.14 expects. This issue should be fixed in recent spack `develop`, but we'd rather not require the cutting edge spack. See https://github.com/spack/spack/pull/16954

@cwsmith @suchyta1 
