### PR TITLE
spack: don't include effis in wdmapp meta package

### DIFF
--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -17,6 +17,10 @@ packages:
   hwloc:
     version: [1.11.11]
 
+  effis:
+    version: [develop]
+    variants: "python-type=full"
+
   openmpi:
     version: [3.1.4]
     variants: "+pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm"

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -28,11 +28,10 @@ class Wdmapp(BundlePackage):
             description='Build TAU version needed for performance analysis of the coupled codes')
 
     # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
-    # CWS - If the variant is not specified for hdf5 and effis then there are
-    # concretization errors associated with hdf5 and python. I think this is related 
+    # CWS - If the variant is not specified for hdf5 then there are
+    # concretization errors associated with hdf5. I think this is related 
     # to https://github.com/spack/spack/issues/15478 .
     depends_on('hdf5 +hl', when='~passthrough')
-    depends_on('effis', when='~passthrough')
     #normal
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='~passthrough')
@@ -43,7 +42,6 @@ class Wdmapp(BundlePackage):
 
     # variant +passthrough
     depends_on('hdf5 +hl', when='+passthrough')
-    depends_on('effis', when='+passthrough')
     depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+passthrough')
     depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana -adios2',

--- a/summit/spack/packages-extended.yaml
+++ b/summit/spack/packages-extended.yaml
@@ -55,6 +55,10 @@ packages:
       cuda@10.1.243: /sw/summit/cuda/10.1.243
     buildable: false
 
+  effis:
+    version: [develop]
+    variants: "python-type=full"
+
 #  cmake:
 #    paths:
 #      cmake@3.15.2: /sw/summit/.swci/0-core/opt/spack/20180914/linux-rhel7-ppc64le/gcc-4.8.5/cmake-3.15.2-xit2o3iepxvqbyku77lwcugufilztu7t

--- a/summit/spack/packages.yaml
+++ b/summit/spack/packages.yaml
@@ -19,6 +19,10 @@ packages:
       cuda@10.1.243: /sw/summit/cuda/10.1.243
     buildable: False
 
+  effis:
+    version: [develop]
+    variants: "python-type=full"
+
   # build a libfabric that actually supports RDMA
   libfabric:
     variants: fabrics=sockets,tcp,udp,verbs,rxm


### PR DESCRIPTION
The "useful" EFFIS needs to be built with python=type=full, so that
job composition/submission etc is available.

Unfortunately, it is not possible to do this variant in the metapackage,
since it requires python3, but xgc requires python2 via petsc, and spack
does not allow for that.

Instead the defaults for EFFIS are set in packages.yaml so that a separate
`spack install effis` will do the right thing.