### PR TITLE
libfabric@1.6.1 on Rhea

### DIFF
--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -26,3 +26,10 @@ packages:
     variants: "+pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm"
     paths:
       'openmpi@3.1.4 +pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm % gcc@8.4.0': /autofs/nccs-svm1_sw/rhea/.swci/0-core/opt/spack/20191017/linux-rhel7-x86_64/gcc-8.4.0/openmpi-3.1.4-bmn7or3eq2xi2sol4f7yvlpnwniut7yd
+
+  libfabric:
+    version: [1.6.1]
+    variants: 'fabrics=verbs'
+
+  tau:
+    variants: "-papi"

--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -30,6 +30,3 @@ packages:
   libfabric:
     version: [1.6.1]
     variants: 'fabrics=verbs'
-
-  tau:
-    variants: "-papi"


### PR DESCRIPTION
- Tau variant `-papi` is because of #51 
- Newer version of `libfabric` and RDMA don't work properly (yet) on Rhea.