### PR TITLE
+effis installation version

### DIFF
--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -26,3 +26,10 @@ packages:
     variants: "+pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm"
     paths:
       'openmpi@3.1.4 +pmi +thread_multiple +legacylaunchers fabrics=ucx schedulers=slurm % gcc@8.4.0': /autofs/nccs-svm1_sw/rhea/.swci/0-core/opt/spack/20191017/linux-rhel7-x86_64/gcc-8.4.0/openmpi-3.1.4-bmn7or3eq2xi2sol4f7yvlpnwniut7yd
+
+  libfabric:
+    version: [1.6.1]
+    variants: 'fabrics=verbs'
+
+  tau:
+    variants: "-papi"

--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -30,6 +30,3 @@ packages:
   libfabric:
     version: [1.6.1]
     variants: 'fabrics=verbs'
-
-  tau:
-    variants: "-papi"

--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -12,7 +12,6 @@ class Effis(CMakePackage):
 
     version('effis',   git='https://github.com/wdmapp/effis.git', branch='effis',   preferred=True)
     version('develop', git='https://github.com/wdmapp/effis.git', branch='develop', preferred=False)
-    version('kittie',  git='https://github.com/wdmapp/effis.git', branch='kittie',  preferred=False)
 
     variant("mpi", default=True, description="Use MPI")
     variant("python-type", default="minimal", description="Python support", values=["minimal", "full"])
@@ -20,20 +19,21 @@ class Effis(CMakePackage):
 
     depends_on('mpi', when="+mpi")
     depends_on('cmake')
-    depends_on('adios2')
     depends_on('yaml-cpp')
+    depends_on('adios2', when="python-type=minimal")
 
     # Needed for the installation process
     depends_on('python@2.7.12:', type=('build', 'run'))
     depends_on('py-setuptools')
 
     # These are not needed for non-Python application use of EFFIS
-    conflicts("python@:2.7.99", when="python-type=full")
+    depends_on("python@3.7.0:", when="python-type=full")
     depends_on('py-pyyaml',     when="python-type=full")         # Needed with EFFIS that composes/submits job AND Python app EFFIS imports
     depends_on('py-numpy',      when="python-type=full")         # Needed with EFFIS that composes/submits job AND Python app EFFIS imports
     depends_on('py-mpi4py',     when="python-type=full +mpi")    # Needed with Python app EFFIS imports
     depends_on('codar-cheetah', when="python-type=full")         # Needed with EFFIS that composes/submits job
     depends_on('py-matplotlib', when="python-type=full")         # Needed with EFFIS that composes/submits job
+    depends_on('adios2+python', when="python-type=full")
 
 
     def cmake_args(self):

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -26,25 +26,21 @@ class Wdmapp(BundlePackage):
             description='Build legacy XGC1/coupling code')
     variant('tau', default=True,
             description='Build TAU version needed for performance analysis of the coupled codes')
+    variant('effis', default=False,
+            description='Enable EFFIS')
 
-    # FIXME this is a hack to avoid Spack not finding a feasible hdf5 on its own
-    # CWS - If the variant is not specified for hdf5 then there are
-    # concretization errors associated with hdf5. I think this is related 
-    # to https://github.com/spack/spack/issues/15478 .
-    depends_on('hdf5 +hl', when='~passthrough')
-    #normal
+    # normal
     depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='~passthrough')
-    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana -adios2',
+    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana +adios2',
         when='~passthrough')
     depends_on('coupler@master',
         when='~passthrough')
 
     # variant +passthrough
-    depends_on('hdf5 +hl', when='+passthrough')
     depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+passthrough')
-    depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana -adios2',
+    depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana +adios2',
         when='+passthrough')
     depends_on('coupler@develop',
         when='+passthrough')
@@ -55,4 +51,22 @@ class Wdmapp(BundlePackage):
 
     # variant +tau
     depends_on('tau@develop +adios2 ~libunwind ~pdt +mpi', when='+tau')
+
+    # variant +effis
+    depends_on('effis python-type=minimal', when='+effis')
+    depends_on('gene@coupling +effis', when='~passthrough +effis')
+    depends_on('xgc-devel@wdmapp +effis', when='~passthrough +effis')
+
+
+    # FIXME these are hacks to avoid Spack not finding a feasible packages on its own
+    # CWS - If the variant is not specified for hdf5 then there are
+    # concretization errors associated with hdf5. I think this is related 
+    # to https://github.com/spack/spack/issues/15478 .
+
+    # Contretization fixes
+    depends_on('adios  +fortran +sz')
+    depends_on('adios2 +fortran +sz')   # The ADIOS +sz (+fortran) is to be explicit, but it's the default
+    depends_on('sz@:1.4.12.99')         # ADIOS1 needs sz < 2.0.0, ADIOS2 defaults to sz > 2.0.0
+    depends_on('hdf5 +hl +fortran')     # PETSc needes +hl, Apps need +fortran
+    depends_on('python@:2.9.99')        # PETSc 3.7.7 needs Python 2.7, EFFIS defaults to Python 3
 

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -26,7 +26,7 @@ class Wdmapp(BundlePackage):
             description='Build legacy XGC1/coupling code')
     variant('tau', default=True,
             description='Build TAU version needed for performance analysis of the coupled codes')
-    variant('effis', default=False,
+    variant('effis', default=True,
             description='Enable EFFIS')
 
     # normal

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -24,6 +24,8 @@ class XgcDevel(CMakePackage):
             description='Enable XGC_GENE_COUPLING')
     variant('cabana', default=True,
             description='Enable Kokkos/Cabana kernels')
+    variant('effis', default=False,
+            description='Enable EFFIS')
 
     depends_on('petsc@3.7.0:3.7.999 ~complex +double')
     depends_on('pkgconfig')
@@ -34,6 +36,7 @@ class XgcDevel(CMakePackage):
     depends_on('cabana@develop', when='+cabana')
     depends_on('pspline')
     depends_on('camtimers')
+    depends_on('effis', when='+effis')
 
     def cmake_args(self):
         spec = self.spec
@@ -47,5 +50,6 @@ class XgcDevel(CMakePackage):
         args += ['-DXGC_GENE_COUPLING={}'.format('ON' if '+coupling_core_edge_gene' in spec else 'OFF')]
         args += ['-DUSE_SYSTEM_PSPLINE=ON']
         args += ['-DUSE_SYSTEM_CAMTIMERS=ON']
+        args += ['-DEFFIS={}'.format('ON' if '+effis' in spec else 'OFF')]
         return args
 


### PR DESCRIPTION
I added a `+effis` variant to install (non-passthrough) XGC and GENE with EFFIS turned on, and made some improvements to the EFFIS package file. A `spack install effis` is still needed for the composition front-end, but that of course can't be added to the same package due to the single concretization. 