### PR TITLE
docs updates

### DIFF
--- a/docs/machines/aimos.rst
+++ b/docs/machines/aimos.rst
@@ -1,5 +1,5 @@
 
-WDMApp on AiMOS
+WDMApp on AiMOS at RPI
 *****************************
 
 AiMOS is a 268 node IBM AC922 system with 2x IBM P9 and 6x NVIDIA V100 GPUs with

--- a/docs/machines/longhorn.rst
+++ b/docs/machines/longhorn.rst
@@ -1,5 +1,5 @@
 
-WDMapp on Longhorn
+WDMapp on Longhorn at TACC
 *************************************
 
 Setting up Spack

--- a/docs/machines/longhorn.rst
+++ b/docs/machines/longhorn.rst
@@ -5,46 +5,31 @@ WDMapp on Longhorn at TACC
 Setting up Spack
 ====================
 
-Follow the generic instructions from  :ref:`setup-spack-label` to install Spack and add the
-WDMapp Spack package repository.
+.. include:: ../spack/setup-intro.rst
 
-.. todo:: adopt the following for longhorn
+.. include:: ../spack/installing-spack.rst
 
-Using Provided Basic Spack Setup for Longhorn
-----------------------------------------------
-	  
-Longhorn is currentlt pretty bare bones in terms of software
-installed, but with some patience, Spack will install most things for
-you.
+.. include:: ../spack/cloning-wdmapp-config.rst
+	     
+Longhorn-Specific Setup
+=========================
 
-The following describes how to use the pre-installed openmpi 3.1.2 + gcc
-7.3.0.
-
-You can copy your choice of a basic or a more comprehensive setup for
-Spack on Longhorn from the
-`<https://github.com/wdmapp/wdmapp-config/tree/master/longhorn/spack>`_ repository.
- 
-.. code-block:: sh
-
-  $ mkdir -p ~/.spack/linux		
-  $ cp path/to/wdmapp-config/longhorn/spack/*.yaml ~/.spack/linux/
+Employing our provided Spack configuration
+--------------------------------------------
 
 .. warning::
-   This will overwrite an existing Spack configuration, so be careful
-   if you've previously set Spack up. If you have existing config, consider
-   you might want to follow the instructions below for :ref:`longhorn-own-setup-label`.
 
-If you use the provided ``packages.yaml``, it only tells Spack about
-essential existing pre-installed packages on Summit, ie., CUDA, MPI
-and the corresponding compilers. Spack will therefore build and
-install all other dependencies from scratch, which takes time but has
-the advantage that it'll generate pretty much the same software stack
-on any machine you use.
+   The folllowing will overwrite an existing Spack configuration, so be careful
+   if you've previously set up Spack. If you have an existing config, consider
+   renaming ``~./spack`` to back it up.
 
-On the other hand, ``packages-extended.yaml`` (which needs to be
-renamed to ``packages.yaml`` to use it), tells Spack comprehensively
-about pre-installed software on Summit, so installation of WDMapp will
-proceed more quickly and use system-provided libraries where possible.
+Just copy the provided YAML configuration files to where Spack
+expects them:
+
+.. code-block:: sh
+
+   $ mkdir -p ~/.spack/linux
+   $ cp path/to/wdmapp-config/longhorn/spack/*.yaml ~/.spack/linux
 
 .. note::
 
@@ -58,13 +43,6 @@ proceed more quickly and use system-provided libraries where possible.
 
       module unload xl spectrum-mpi
    
-.. note::
-
-   On Longhorn, the cuda module sets environment variables that set a
-   path which ``nvcc`` does not otherwise add. Because of this, it is
-   requried to ``module load cuda/10.1.243`` before building GENE, and
-   probably other software that uses CUDA..
-
 .. _longhorn-own-setup-label:
 
 Creating your own setup for Longhorn
@@ -183,28 +161,3 @@ Building WDMapp
 You should be able to just follow the generic instructions from
 :ref:`build-wdmapp-label`.
 
-Running a Sample Job
-====================
-
-.. todo::
-
-   Complete instructions on how to get the test case set up and run.
-
-You can get the setup for a coupled WDMapp run by cloning
-https://github.com/wdmapp/testcases.
-
-The sample sample job from
-https://github.com/wdmapp/wdmapp-config/longhorn/submit_wdmapp.sh will
-run the `run_1` coupled case.
-
-.. literalinclude:: ../../summit/submit_wdmapp.sh
-   :language: shell
-   :linenos:
-
-Submit as usal:
-
-.. code-block:: sh
-
-   $ sbatch submit_wdmapp.sh
-
- 

--- a/docs/machines/note-olcf-shared-spack.rst
+++ b/docs/machines/note-olcf-shared-spack.rst
@@ -1,0 +1,35 @@
+
+
+Rhea and Summit share a common home directory. If you use Spack on
+both machines, this leads to issues because both instances will share
+their config files, which by default go into ```~/.spack/linux``. If
+you only want to use just one or the other machine, you can ignore the following note.
+	     
+.. note::
+
+
+   One way to deal with keeping separate spack setups on Rhea and Summit is to make separate
+   ``~/.spack/linux-rhea`` and ``~/spack/linux-summit`` directories and
+   symlink one or the other to ``~/.spack/linux``
+
+   .. code-block:: sh
+
+      $ # make sure ~/.spack/linux does exit yet -- if it does, move it  out of the way		
+      $ mkdir -p ~/.spack/linux-rhea
+      $ mkdir -p ~/.spack/linux-summit
+      $ ln -snf ~/.spack/linux-rhea ~/.spack/linux # if on rhea
+      $ ln -snf ~/.spack/linux-summit ~/.spack/linux # if on summit
+
+   An alternative is to have two separate spack installs, and instead of keeping the config files
+   in ``~/.spack``, they can be put into ``$SPACK_ROOT/etc``, so with two different roots they
+   can be kept separate. You can then do this in your ``.bashrc``:
+
+   .. code-block:: sh
+
+       if [ `uname -m` == "ppc64le" ]; then
+         export SPACK_ROOT=$HOME/spack-summit
+       else
+         export SPACK_ROOT=$HOME/spack-rhea
+       fi
+       source $SPACK_ROOT/share/spack/setup-env.sh		   
+

--- a/docs/machines/note-olcf-spack-dir.rst
+++ b/docs/machines/note-olcf-spack-dir.rst
@@ -9,7 +9,7 @@
 
       $ mkdir -p /gpfs/alpine/scratch/$USER/spack-stage
 
-      and add the following to ``~/.spack/config.yaml``:
+   and add the following to ``~/.spack/config.yaml``:
 
    .. code-block:: yaml
 

--- a/docs/machines/note-olcf-spack-dir.rst
+++ b/docs/machines/note-olcf-spack-dir.rst
@@ -1,0 +1,19 @@
+
+.. note::
+  
+   Consider also configuring spack to use gpfs scratch space (i.e. ``$MEMBERWORK``)
+   when building packages, rather than the home filesystem which tends to have
+   problems with high workload tasks:
+
+   .. code-block:: sh
+
+      $ mkdir -p /gpfs/alpine/scratch/$USER/spack-stage
+
+      and add the following to ``~/.spack/config.yaml``:
+
+   .. code-block:: yaml
+
+      config:
+        build_stage: /gpfs/alpine/scratch/$user/spack-stage
+
+

--- a/docs/machines/rhea.rst
+++ b/docs/machines/rhea.rst
@@ -44,6 +44,8 @@ Building WDMapp
 You should be able to just follow the generic instructions from
 :ref:`build-wdmapp-label`.
 
+.. _rhea-running-cyclone-label:
+
 Running the Cyclone Test Case
 =============================
 
@@ -62,6 +64,7 @@ Enable shell support for Spack:
 Load the wdmapp modules:
 
 .. code-block:: sh
+
   $ spack load effis arch=linux-rhel7-sandybridge
   $ spack load wdmapp arch=linux-rhel7-sandybridge
 
@@ -100,7 +103,7 @@ Running the Cyclone Test Case - External Coupler
 ================================================
 
 The cyclone test case can be executed with the external coupler
-(`wdmapp+passthrough` built in :ref:`build-wdmapp-label`) by
-following the instructions for :ref:`Running the Cyclone Test Case` using
+(``wdmapp+passthrough`` built in :ref:`build-wdmapp-label` by
+following the instructions for :ref:`rhea-running-cyclone-label` using
 ``run_externalCpl.yaml`` instead of ``run_1.yaml``.
 

--- a/docs/machines/rhea.rst
+++ b/docs/machines/rhea.rst
@@ -1,5 +1,5 @@
 
-WDMApp on Rhea
+WDMApp on Rhea at OLCF
 *****************************
 
 Setting up Spack

--- a/docs/machines/rhea.rst
+++ b/docs/machines/rhea.rst
@@ -5,38 +5,46 @@ WDMApp on Rhea at OLCF
 Setting up Spack
 ====================
 
-Follow the generic instructions from  :ref:`setup-spack-label` to install Spack and add the
-WDMapp package repository.
+.. include:: ../spack/setup-intro.rst
 
+.. include:: ../spack/installing-spack.rst
+
+.. include:: ../spack/cloning-wdmapp-config.rst
+	     
 Rhea-Specific Setup
--------------------------
+======================
 
-.. code-block:: sh
+.. include:: note-olcf-shared-spack.rst
 
-  $ mkdir -p ~/.spack/linux-rhea
-  $ cp path/to/wdmapp-config/rhea/spack/*.yaml ~/.spack/linux-rhea
-  $ ln -snf ~/.spack/linux-rhea linux
+Employing our provided Spack configuration
+--------------------------------------------
 
 .. warning::
 
-   This will overwrite an existing Spack configuration, so be careful
-   if you've previously set Spack up. If you have an existing config, consider
-   moving ``~./spack`` to back it up.
+   The folllowing will overwrite an existing Spack configuration, so be careful
+   if you've previously set up Spack. If you have an existing config, consider
+   renaming ``~./spack`` to back it up.
 
-Consider also configuring spack to use gpfs scratch space (i.e. ``$MEMBERWORK``)
-when building packages, rather than the home filesystem which tends to have
-problems with high workload tasks:
+Just copy the provided YAML configuration files to where Spack
+expects them:
 
 .. code-block:: sh
 
-  $ mkdir -p /gpfs/alpine/scratch/$USER/spack-stage
+   $ mkdir -p ~/.spack/linux
+   $ cp path/to/wdmapp-config/rhea/spack/*.yaml ~/.spack/linux
 
-and add the following to ``~/.spack/config.yaml``:
+On Rhea an ``olcf`` repo is also needed to make it possible to use
+system-installed packages from our Spack. This repo is provided by the
+`wdmapp-config` you cloned earlier:
 
-.. code-block:: yaml
+.. code-block:: sh
 
-  config:
-    build_stage: /gpfs/alpine/scratch/$user/spack-stage
+  $ spack repo add path/to/wdmapp-config/rhea/spack/olcf
+  ==> Added repo with namespace 'olcf'
+
+.. include:: note-olcf-spack-dir.rst
+  
+.. include:: ../spack/adding-wdmapp.rst
 
 Building WDMapp
 ================

--- a/docs/machines/summit.rst
+++ b/docs/machines/summit.rst
@@ -1,5 +1,5 @@
 
-WDMApp on Summit
+WDMApp on Summit at OLCF
 *****************************
 
 Setting up Spack

--- a/docs/machines/summit.rst
+++ b/docs/machines/summit.rst
@@ -5,28 +5,39 @@ WDMApp on Summit at OLCF
 Setting up Spack
 ====================
 
-Follow the generic instructions from  :ref:`setup-spack-label` to install Spack and add the
-WDMapp Spack package repository.
+.. include:: ../spack/setup-intro.rst
 
+.. include:: ../spack/installing-spack.rst
+
+.. include:: ../spack/cloning-wdmapp-config.rst
+	     
 Summit-Specific Setup
 -------------------------
 
-You can copy your choice of a basic or a more comprehensive setup for
-Spack on Summit from the
-`<https://github.com/wdmapp/wdmapp-config/tree/master/summit/spack>`_ repository.
+.. include:: note-olcf-shared-spack.rst
 
-.. code-block:: sh
-
-  $ mkdir -p ~/.spack/linux-summit
-  $ cp path/to/wdmapp-config/summit/spack/*.yaml ~/.spack/linux-summit
-  $ ln -snf ~/.spack/linux-summit linux
+Employing our provided Spack configuration
+--------------------------------------------
 
 .. warning::
 
-   This will overwrite an existing Spack configuration, so be careful
-   if you've previously set Spack up. If you have an existing config, consider
-   using ``path/to/spack/etc/spack/package.yaml`` for packages instead, and add
-   gcc 8.1.1 to your exising ``compilers.yaml`` if not already present.
+   The folllowing will overwrite an existing Spack configuration, so be careful
+   if you've previously set up Spack. If you have an existing config, consider
+   renaming ``~./spack`` to back it up.
+
+Just copy the provided YAML configuration files to where Spack
+expects them:
+
+.. code-block:: sh
+
+   $ mkdir -p ~/.spack/linux
+   $ cp path/to/wdmapp-config/summit/spack/*.yaml ~/.spack/linux
+
+      
+You can have a choice of a basic or a more comprehensive setup for
+Spack on Summit from the `wdmapp-config
+<https://github.com/wdmapp/wdmapp-config/tree/master/summit/spack>`_
+repository.
 
 If you use the provided ``packages.yaml``, it only tells Spack about
 essential existing pre-installed packages on Summit, ie., CUDA, MPI
@@ -36,7 +47,7 @@ the advantage that it'll generate pretty much the same software stack
 on any machine you use.
 
 On the other hand, ``packages-extended.yaml`` (which needs to be
-renamed to ``packages.yaml`` to use it), tells Spack comprehensively
+renamed to ``packages.yaml`` to be used), tells Spack comprehensively
 about pre-installed software on Summit, so installation of WDMapp will
 proceed more quickly and use system-provided libraries where possible.
 
@@ -59,22 +70,9 @@ proceed more quickly and use system-provided libraries where possible.
    requried to ``module load cuda/10.1.243`` before building GENE, and
    probably other software that uses CUDA..
 
-Consider also configuring spack to use gpfs scratch space (i.e. ``$MEMBERWORK``)
-when building packages, rather than the home filesystem which tends to have
-problems with high workload tasks:
+.. include:: note-olcf-spack-dir.rst
 
-.. code-block:: sh
-
-  $ mkdir -p /gpfs/alpine/scratch/$USER/spack-stage
-
-and add the following to ``~/.spack/config.yaml``:
-
-.. code-block:: yaml
-
-  config:
-    build_stage: /gpfs/alpine/scratch/$user/spack-stage
-   
-
+.. include:: ../spack/adding-wdmapp.rst
 
 Building WDMapp
 ================

--- a/docs/spack/adding-wdmapp.rst
+++ b/docs/spack/adding-wdmapp.rst
@@ -1,0 +1,24 @@
+
+Adding the WDMapp package repo to Spack
+=============================================
+
+This will let Spack search the WDMapp repository for packages that
+aren't found in its builtin package repository.
+
+.. code-block:: sh
+
+  $ spack repo add path/to/wdmapp-config/spack/wdmapp
+  ==> Added repo with namespace 'wdmapp'.
+
+.. note::
+
+  To update the wdmapp package repository to the latest, just run ``git
+  pull`` in the directory where you cloned ``wdmapp-config/``.
+
+On Rhea an ``olcf`` repo is also needed:
+
+.. code-block:: sh
+
+  $ spack repo add path/to/wdmapp-config/rhea/spack/olcf
+  ==> Added repo with namespace 'olcf'
+

--- a/docs/spack/adding-wdmapp.rst
+++ b/docs/spack/adding-wdmapp.rst
@@ -15,10 +15,3 @@ aren't found in its builtin package repository.
   To update the wdmapp package repository to the latest, just run ``git
   pull`` in the directory where you cloned ``wdmapp-config/``.
 
-On Rhea an ``olcf`` repo is also needed:
-
-.. code-block:: sh
-
-  $ spack repo add path/to/wdmapp-config/rhea/spack/olcf
-  ==> Added repo with namespace 'olcf'
-

--- a/docs/spack/cloning-wdmapp-config.rst
+++ b/docs/spack/cloning-wdmapp-config.rst
@@ -1,0 +1,13 @@
+
+Cloning the WDMapp package repo
+=========================================
+
+Just clone the repository from `github
+<https://github.com/wdmapp/wdmapp-config/>`_ to the same machine that
+you just set up Spack on.
+
+.. code-block:: sh
+
+   $ git clone https://github.com/wdmapp/wdmapp-config
+
+

--- a/docs/spack/installing-spack.rst
+++ b/docs/spack/installing-spack.rst
@@ -1,0 +1,30 @@
+
+Installing Spack
+======================
+
+Follow the instructions from the `Spack Documentation 
+<http://https://spack.readthedocs.io/en/latest/getting_started.html/>`_.
+
+.. code-block:: sh
+
+   $ git clone -b releases/v0.14 https://github.com/spack/spack.git
+   
+.. note::
+
+   v0.14 is the latest spack stable version on 2020-03-17; newer versions
+   will likely work but have not been tested. Using the default 'develop'
+   branch is not recommended, as it does break sometimes and introduces
+   a lot of package version churn if you try to track it.
+
+Enable shell support for Spack.
+
+.. code-block:: sh
+
+  # For bash/zsh users
+  $ export SPACK_ROOT=/path/to/spack
+  $ . $SPACK_ROOT/share/spack/setup-env.sh
+
+  # For tcsh or csh users (note you must set SPACK_ROOT)
+  $ setenv SPACK_ROOT /path/to/spack
+  $ source $SPACK_ROOT/share/spack/setup-env.csh
+

--- a/docs/spack/setup-intro.rst
+++ b/docs/spack/setup-intro.rst
@@ -3,6 +3,6 @@ Spack is a generic package manager for HPC. We rely on it in the following to in
 WDMapp and its components. Setting up Spack is a one-time process on a given machine
 -- if you already have a working Spack install, you should be able to use it.
 However, in practice there are plenty of ways that things can wrong, so we provide
-tested Spack setups for a selection of machines. Following our instructions makes sure,
-that, e.g., our codes are built with compatible compilers.
+tested Spack setups for a selection of machines.
+Following our instructions makes sure that WDMapp is built with compatible compilers and machine-specific system packages (e.g., MPI, CUDA, etc.).
 

--- a/docs/spack/setup-intro.rst
+++ b/docs/spack/setup-intro.rst
@@ -1,0 +1,8 @@
+
+Spack is a generic package manager for HPC. We rely on it in the following to install
+WDMapp and its components. Setting up Spack is a one-time process on a given machine
+-- if you already have a working Spack install, you should be able to use it.
+However, in practice there are plenty of ways that things can wrong, so we provide
+tested Spack setups for a selection of machines. Following our instructions makes sure,
+that, e.g., our codes are built with compatible compilers.
+

--- a/docs/spack/setup.rst
+++ b/docs/spack/setup.rst
@@ -4,83 +4,15 @@
 Setting up Spack
 *****************
 
-Setting up Spack on a given machine should be a one-time process, and
-ideally shouldn't be specific to the codes you're planning to build.
+.. include:: setup-intro.rst
 
-.. note::
+.. include:: installing-spack.rst
 
-   In practice you might want to set up multiple compilers etc, and
-   then have certain projects build using some specific compiler, and
-   so on. Spack allows you to specify details like this when
-   installating a package, but it might be useful to use Spack
-   environments so that you don't have to remember to keep specifying
-   those details over and over again.
+.. include:: cloning-wdmapp-config.rst
+	     
+.. include:: adding-wdmapp.rst	  
 
-Installing Spack
-======================
-
-Follow the instructions from the `Spack Documentation 
-<http://https://spack.readthedocs.io/en/latest/getting_started.html/>`_.
-
-.. code-block:: sh
-
-   $ git clone -b releases/v0.14 https://github.com/spack/spack.git
-   
-.. note::
-
-   v0.14 is the latest spack stable version on 2020-03-17; newer versions
-   will likely work but have not been tested. Using the default 'develop'
-   branch is not recommended, as it does break sometimes and introduces
-   a lot of package version churn if you try to track it.
-
-Enable shell support for Spack.
-
-.. code-block:: sh
-
-  # For bash/zsh users
-  $ export SPACK_ROOT=/path/to/spack
-  $ . $SPACK_ROOT/share/spack/setup-env.sh
-
-  # For tcsh or csh users (note you must set SPACK_ROOT)
-  $ setenv SPACK_ROOT /path/to/spack
-  $ source $SPACK_ROOT/share/spack/setup-env.csh
-
-Cloning the ``WDMapp-config`` repository
-========================================
-
-Just clone the repository from `github
-<https://github.com/wdmapp/wdmapp-config/>`_ to the same machine that
-you just set up Spack on.
-
-.. code-block:: sh
-
-   $ git clone https://github.com/wdmapp/wdmapp-config
-   
-
-
-Adding the WDMapp package repo to Spack
-=============================================
-
-This will let Spack search the WDMapp repository for packages that
-aren't found in its builtin package repository.
-
-.. code-block:: sh
-
-  $ spack repo add path/to/wdmapp-config/spack/wdmapp
-  ==> Added repo with namespace 'wdmapp'.
-
-On Rhea an ``olcf`` repo is also needed:
-
-.. code-block:: sh
-
-  $ spack repo add path/to/wdmapp-config/rhea/spack/olcf
-  ==> Added repo with namespace 'olcf'
-
-.. note::
-
-  To update the wdmapp package repository to the latest, just run ``git
-  pull`` in the directory where you cloned ``wdmapp-config/``.
-
+	     
 Machine-Specific Setup
 ======================
 


### PR DESCRIPTION
This updates the docs to use common text blocks so that each machine has a single page that avoids referring to generic instructions but rather includes the necessary text directly (however, the change is only for the spack setup part, it should also be done for the actual "Building wdmapp" part).

It also fixes a bunch of other bits and pieces along the way.

Still needs more work, but I'll call it progress...