### PR TITLE
Update effis options so Python can be turned off altogether

### DIFF
--- a/rhea/spack/packages.yaml
+++ b/rhea/spack/packages.yaml
@@ -20,7 +20,6 @@ packages:
 
   effis:
     version: [develop]
-    variants: "python-type=full"
 
   openmpi:
     version: [3.1.4]

--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -9,32 +9,32 @@ class Effis(CMakePackage):
 
     homepage = "https://github.com/wdmapp/effis"
     url = homepage
-
     version('effis',   git='https://github.com/wdmapp/effis.git', branch='effis',   preferred=True)
     version('develop', git='https://github.com/wdmapp/effis.git', branch='develop', preferred=False)
 
     variant("mpi", default=True, description="Use MPI")
-    variant("python-type", default="minimal", description="Python support", values=["minimal", "full"])
     variant("shared", default=True, description="Build shared library")
+    variant("python", default=True, description="enable python")
+    variant("compose", default=True, description="enable front-end compose")
 
     depends_on('mpi', when="+mpi")
     depends_on('cmake')
     depends_on('yaml-cpp')
-    depends_on('adios2', when="python-type=minimal")
 
-    # Needed for the installation process
-    extends('python')
-    depends_on('python@2.7.12:', type=('build', 'run'))
-    depends_on('py-setuptools')
+    depends_on('adios2 -mpi', when="-mpi")
+    depends_on('adios2 +mpi', when="+mpi")
+    depends_on('adios2', when="-python")
+    depends_on('adios2 +python', when="+python")
 
-    # These are not needed for non-Python application use of EFFIS
-    depends_on("python@3.7.0:", when="python-type=full")
-    depends_on('py-pyyaml',     when="python-type=full")         # Needed with EFFIS that composes/submits job AND Python app EFFIS imports
-    depends_on('py-numpy',      when="python-type=full")         # Needed with EFFIS that composes/submits job AND Python app EFFIS imports
-    depends_on('py-mpi4py',     when="python-type=full +mpi")    # Needed with Python app EFFIS imports
-    depends_on('codar-cheetah', when="python-type=full")         # Needed with EFFIS that composes/submits job
-    depends_on('py-matplotlib', when="python-type=full")         # Needed with EFFIS that composes/submits job
-    depends_on('adios2+python', when="python-type=full")
+    extends('python', when="+python")
+    depends_on('python@2.7.12:', when="+python")
+    depends_on('py-setuptools',  when="+python")
+    depends_on('py-pyyaml',      when="+python")
+    depends_on('py-numpy',       when="+python")
+    depends_on('py-mpi4py',      when="+python +mpi")
+    depends_on('py-matplotlib',  when="+python")
+
+    depends_on('codar-cheetah', when="+compose")
 
 
     def cmake_args(self):

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -53,7 +53,7 @@ class Wdmapp(BundlePackage):
     depends_on('tau@develop +adios2 ~libunwind ~pdt +mpi', when='+tau')
 
     # variant +effis
-    depends_on('effis python-type=minimal', when='+effis')
+    depends_on('effis -python -compose', when='+effis')
     depends_on('gene@coupling +effis', when='~passthrough +effis')
     depends_on('xgc-devel@wdmapp +effis', when='~passthrough +effis')
 


### PR DESCRIPTION
This makes the EFFIS Spack variants simpler, as well as makes installation more robust if Python isn't actually needed, cf. #61 when an Anaconda Python 2 distribution is used.