### PR TITLE
Add conflicts to make sure +compose uses +python in EFFIS

### DIFF
--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -34,6 +34,7 @@ class Effis(CMakePackage):
     depends_on('py-mpi4py',      when="+python +mpi")
     depends_on('py-matplotlib',  when="+python")
 
+    conflicts("-python", when="+compose")
     depends_on('codar-cheetah', when="+compose")
 
 


### PR DESCRIPTION
Very minor here. Title says it all.