### PR TITLE
docs updates for e4s build cache

### DIFF
--- a/docs/machines/cyclone-run.rst
+++ b/docs/machines/cyclone-run.rst
@@ -14,4 +14,4 @@ Submit the job:
 
 .. code-block:: sh
 
-  $ effis-submit.py /path/to/testDir
+  $ effis-submit /path/to/testDir

--- a/docs/machines/rhea.rst
+++ b/docs/machines/rhea.rst
@@ -46,6 +46,21 @@ system-installed packages from our Spack. This repo is provided by the
   
 .. include:: ../spack/adding-wdmapp.rst
 
+.. note::
+
+   The E4S prjoect has created a build cache for Rhea. This provides many
+   packages as precompiled binaries, so will reduce the installation
+   time. To use it:
+
+   .. code-block:: sh
+
+      $ wget https://oaciss.uoregon.edu/e4s/e4s.pub
+      $ spack gpg trust e4s.pub
+      $ spack mirror add E4S https://cache.e4s.io/e4s
+		  
+
+   
+
 Building WDMapp
 ================
 


### PR DESCRIPTION
A minor fix to the docs, as well as instructions on how to use the E4S build cache on rhea