### PR TITLE
Update Summit packages.yaml for new EFFIS variants

### DIFF
--- a/summit/spack/packages-extended.yaml
+++ b/summit/spack/packages-extended.yaml
@@ -57,7 +57,6 @@ packages:
 
   effis:
     version: [develop]
-    variants: "python-type=full"
 
 #  cmake:
 #    paths:
@@ -166,10 +165,6 @@ packages:
   gmp:
     paths:
       gmp@6.0.0: /usr
-
-  libpng:
-    paths:
-      libpng@1.5.13: /usr
 
   libffi:
     paths:

--- a/summit/spack/packages.yaml
+++ b/summit/spack/packages.yaml
@@ -21,7 +21,6 @@ packages:
 
   effis:
     version: [develop]
-    variants: "python-type=full"
 
   # build a libfabric that actually supports RDMA
   libfabric:


### PR DESCRIPTION
The `libpng` part was removed because ADIOS2 needs `libpng > 1.6`, but `matplotlib` can use an older version, and the path to `1.5.13` was causing Spack to try to use that and throwing an error.