### PR TITLE
effis always needs python2.7.12 for the preprocessor

### DIFF
--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -27,7 +27,7 @@ class Effis(CMakePackage):
     depends_on('adios2 +python', when="+python")
 
     extends('python', when="+python")
-    depends_on('python@2.7.12:', when="+python")
+    depends_on('python@2.7.12:')
     depends_on('py-setuptools',  when="+python")
     depends_on('py-pyyaml',      when="+python")
     depends_on('py-numpy',       when="+python")


### PR DESCRIPTION
The effis preprocessor converts effis pragmas in the source code to effis C++/Fortran api calls.  If the effis front-end (supports job composition and execution/submission) is enabled then Python 3 is required.

Without this fix Effis CMake finds system python 2.7.5 on Rhea which is too old.  That error appears as:

```
-- Found Python: /usr/bin/python2.7 (found version "2.7.5") found components:  Interpreter 
-- Performing Test exists_gnu
-- Performing Test exists_gnu - Success
-- Configuring done
CMake Error at examples/simple/Fortran/CMakeLists.txt:7 (add_executable):
  Cannot find source file:

    /tmp/cwsmith/spack-stage/spack-stage-effis-develop-o6uvusyc4ad5lhkn7syeybpf6frydvgh/spack-build/examples/simple/Fortran/reader-effis.F90

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm 
  .hpp .hxx .in .txx
```