### PR TITLE
spack: tag gene, xgc-devel, effis, camtimers, pspline wdmapp-0.1.0 release

### DIFF
--- a/spack/wdmapp/packages/camtimers/package.py
+++ b/spack/wdmapp/packages/camtimers/package.py
@@ -17,6 +17,7 @@ class Camtimers(CMakePackage):
 
     maintainers = ['germasch', 'bd4']
 
+    version('0.1.0', tag='v0.1.0', preferred=True)
     version('master', branch='master')
 
     depends_on('mpi')

--- a/spack/wdmapp/packages/effis/package.py
+++ b/spack/wdmapp/packages/effis/package.py
@@ -9,8 +9,10 @@ class Effis(CMakePackage):
 
     homepage = "https://github.com/wdmapp/effis"
     url = homepage
-    version('effis',   git='https://github.com/wdmapp/effis.git', branch='effis',   preferred=True)
-    version('develop', git='https://github.com/wdmapp/effis.git', branch='develop', preferred=False)
+    git = 'https://github.com/wdmapp/effis.git'
+    version('0.1.0', tag='v0.1.0', preferred=True)
+    version('effis', branch='effis', preferred=False)
+    version('develop', branch='develop', preferred=False)
 
     variant("mpi", default=True, description="Use MPI")
     variant("shared", default=True, description="Build shared library")

--- a/spack/wdmapp/packages/gene/package.py
+++ b/spack/wdmapp/packages/gene/package.py
@@ -16,9 +16,10 @@ class Gene(CMakePackage, CudaPackage):
 
     maintainers = ['germasch', 'bd4']
 
-    # FIXME: Add proper versions and checksums here.
+    version('wdmapp-0.1.0', tag='wdmapp-0.1.0', preferred=True,
+            submodules=True, submodules_delete=['python-diag'])
     version('cuda_under_the_hood', git="git@gitlab.mpcdf.mpg.de:GENE/gene-dev.git",
-            branch='cuda_under_the_hood', preferred=True,
+            branch='cuda_under_the_hood',
             submodules=True, submodules_delete=['python-diag'])
     version('coupling', branch='coupling',
             submodules=True, submodules_delete=['python-diag'])
@@ -51,7 +52,7 @@ class Gene(CMakePackage, CudaPackage):
     depends_on('pfunit@3.3.3:3.3.99+mpi max_array_rank=6', when='+pfunit')
     depends_on('adios2', when='+adios2')
     depends_on('hdf5+fortran', when='+futils')
-    depends_on('effis', when='+effis')
+    depends_on('effis@0.1.0', when='+effis')
 
     conflicts('+effis', when='~adios2',
               msg='+effis requires +adios2 to also be selected.')

--- a/spack/wdmapp/packages/pspline/package.py
+++ b/spack/wdmapp/packages/pspline/package.py
@@ -15,5 +15,6 @@ class Pspline(CMakePackage):
 
     maintainers = ['germasch', 'bd4']
 
+    version('0.1.0', tag='v0.1.0', preferred=True)
     version('master', branch='master')
 

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -18,7 +18,7 @@ class Wdmapp(BundlePackage):
 
     maintainers = ['germasch', 'bd4']
 
-    version('0.0.1',preferred=True)
+    version('0.1.0',preferred=True)
 
     variant('passthrough', default=False,
             description='Enable pass-through coupler')
@@ -30,9 +30,9 @@ class Wdmapp(BundlePackage):
             description='Enable EFFIS')
 
     # normal
-    depends_on('gene@coupling +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
+    depends_on('gene@wdmapp-0.1.0 +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='~passthrough')
-    depends_on('xgc-devel@wdmapp +coupling_core_edge_gene -cabana +adios2',
+    depends_on('xgc-devel@wdmapp-0.1.0 +coupling_core_edge_gene -cabana +adios2',
         when='~passthrough')
     depends_on('coupler@master',
         when='~passthrough')
@@ -53,9 +53,9 @@ class Wdmapp(BundlePackage):
     depends_on('tau@develop +adios2 ~libunwind ~pdt +mpi', when='+tau')
 
     # variant +effis
-    depends_on('effis -python -compose', when='+effis')
-    depends_on('gene@coupling +effis', when='~passthrough +effis')
-    depends_on('xgc-devel@wdmapp +effis', when='~passthrough +effis')
+    depends_on('effis@0.1.0 -python -compose', when='+effis')
+    depends_on('gene@wdmapp-0.1.0 +effis', when='~passthrough +effis')
+    depends_on('xgc-devel@wdmapp-0.1.0 +effis', when='~passthrough +effis')
 
 
     # FIXME these are hacks to avoid Spack not finding a feasible packages on its own

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -16,7 +16,8 @@ class XgcDevel(CMakePackage):
 
     maintainers = ['germasch', 'bd4', 'cwsmith', 'Damilare06']
 
-    version('wdmapp', branch='wdmapp', preferred=True)
+    version('wdmapp-0.1.0', tag='wdmapp-0.1.0', preferred=True)
+    version('wdmapp', branch='wdmapp')
     version('rpi', branch='rpi')
 
     variant('adios2', default=True,
@@ -49,9 +50,9 @@ class XgcDevel(CMakePackage):
     depends_on('adios2 +fortran', when='+coupling_core_edge_gene')
     depends_on('fftw@3.3.8:')
     depends_on('cabana@develop', when='+cabana')
-    depends_on('pspline')
-    depends_on('camtimers')
-    depends_on('effis', when='+effis')
+    depends_on('pspline@0.1.0')
+    depends_on('camtimers@0.1.0')
+    depends_on('effis@0.1.0', when='+effis')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
FWIW, I don't necessarily like tagging everything with `wdmapp-0.1.0`. I think for gene and xgc-devel, it's needed as to not confuse it with any other official releases. But for EFFIS, you could declare a generic release, and we could use that, and for pspline and camtimers, I don't think they're really wdmapp specific, so I could also give them just a generic version.