### PR TITLE
docs: swap order of spack loads to avoid python error

### DIFF
--- a/docs/machines/rhea.rst
+++ b/docs/machines/rhea.rst
@@ -78,8 +78,8 @@ Load the wdmapp modules:
 
 .. code-block:: sh
 
-  $ spack load effis +compose arch=linux-rhel7-sandybridge
   $ spack load wdmapp arch=linux-rhel7-sandybridge
+  $ spack load effis +compose arch=linux-rhel7-sandybridge
 
 Clone the testcases repo:
 

--- a/docs/machines/summit.rst
+++ b/docs/machines/summit.rst
@@ -89,8 +89,8 @@ Load the wdmapp modules:
 
 .. code-block:: sh
 
-  $ spack load effis +compose arch=linux-rhel7-power9le
   $ spack load wdmapp arch=linux-rhel7-power9le
+  $ spack load effis +compose arch=linux-rhel7-power9le
 
 Clone the testcases repo:
 


### PR DESCRIPTION
`wdmapp` and `effis +compose` are using different versions of python. Loading effis after wdmapp is necessary to run `effis-compose.py` successfully.

If effis is loaded before wdmapp then running `effis-compose.py` produces the following error:

```$ effis-compose.py run_1.yaml
Traceback (most recent call last):
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-sandybridge/gcc-8.4.0/effis-develop-rppt4ve65dvbk262wentbdwu4n7uhs2j/bin/effis-compose.py", line 9, in <module>
    import codar.cheetah as cheetah
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-sandybridge/gcc-8.4.0/codar-cheetah-develop-5lspai3aymvqhjzehsw2uioethho7eiw/lib/python3.7/site-packages/codar/cheetah/__init__.py", line 5, in <module>
    from codar.cheetah.model import Campaign
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-sandybridge/gcc-8.4.0/codar-cheetah-develop-5lspai3aymvqhjzehsw2uioethho7eiw/lib/python3.7/site-packages/codar/cheetah/model.py", line 19, in <module>
    from pathlib import Path
ImportError: No module named pathlib
```