### PR TITLE
spack: add custom perfstubs

### DIFF
--- a/spack/wdmapp/packages/gem/package.py
+++ b/spack/wdmapp/packages/gem/package.py
@@ -26,6 +26,7 @@ class Gem(CMakePackage):
     depends_on('adios +fortran')
     depends_on('adios2@2.5.0: +fortran')
     depends_on('pspline@0.1.0:')
+    depends_on('perfstubs@kg')
 
     def cmake_args(self):
         args = []

--- a/spack/wdmapp/packages/perfstubs/package.py
+++ b/spack/wdmapp/packages/perfstubs/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Perfstubs(CMakePackage):
+    """Profiling API for adding tool instrumentation support to any project.
+
+    This was motivated by the need to quickly add instrumentation to the
+    [ADIOS2](https://github.com/ornladios/ADIOS2) library without adding a build
+    dependency, or tying to a specific measurement tool.
+
+    The initial prototype implementation was tied to TAU, but evolved to this more
+    generic version, which was extracted as a separate repository for testing and
+    demonstration purposes.
+    """
+
+    homepage = "https://github.com/khuck/perfstubs"
+    git      = "https://github.com/khuck/perfstubs.git"
+
+    version('master', branch='master')
+    variant('static', default=False, description='Build static executable support')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DPERFSTUBS_USE_STATIC:BOOL={0}'.format(
+                'ON' if '+static' in spec else 'OFF')
+        ]
+        return args

--- a/spack/wdmapp/packages/perfstubs/package.py
+++ b/spack/wdmapp/packages/perfstubs/package.py
@@ -22,6 +22,8 @@ class Perfstubs(CMakePackage):
     git      = "https://github.com/khuck/perfstubs.git"
 
     version('master', branch='master')
+    version('kg', branch='dev', git='git@github.com:germasch/perfstubs.git')
+    
     variant('static', default=False, description='Build static executable support')
 
     def cmake_args(self):


### PR DESCRIPTION
It's a (temporary) workaround to build a version of perfstubs via spack that can be included in spack/cmake-based projects easily.