### PR TITLE
spack: don't require +adios2 variant of tau

### DIFF
--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -50,7 +50,7 @@ class Wdmapp(BundlePackage):
                when='+xgc1_legacy')
 
     # variant +tau
-    depends_on('tau@develop +adios2 ~libunwind ~pdt +mpi', when='+tau')
+    depends_on('tau@develop ~libunwind ~pdt +mpi', when='+tau')
 
     # variant +effis
     depends_on('effis@0.1.0 -python -compose', when='+effis')


### PR DESCRIPTION
To my knowledge, this isn't actually used, and the latest tau spack package
doesn't have the variant. It could probably be re-added, if someone needs it.

Fixes #89.