### PR TITLE
install coupler that supports successfull xgc-gene coupled cyclone runs

### DIFF
--- a/spack/wdmapp/packages/coupler/package.py
+++ b/spack/wdmapp/packages/coupler/package.py
@@ -9,15 +9,16 @@ from spack import *
 class Coupler(CMakePackage):
     """XGC-GENE coupler."""
 
-    homepage = "https://github.com/SCOREC/wdmapp_coupling"
+    homepage = "https://github.com/wdmapp/wdmapp_coupling"
     # FIXME, there is no tarball, but it still needs a URL, so it's fake
-    url      = "git@github.com:SCOREC/wdmapp_coupling.tar.gz"
-    git      = "git@github.com:SCOREC/wdmapp_coupling.git"
+    url      = "git@github.com:wdmapp/wdmapp_coupling.tar.gz"
+    git      = "git@github.com:wdmapp/wdmapp_coupling.git"
 
     maintainers = ['cwsmith','Damilare06','phyboyzhang']
 
-    version('master', branch='master', preferred=True)
-    version('develop', branch='develop')
+    version('0.1.0', tag='v0.1.0', preferred=True)
+    version('develop', branch='develop',
+      git="git@github.com:SCOREC/wdmapp_coupling.git")
 
     depends_on('pkgconfig', type='build')
     depends_on('cmake@3.13:', type='build')

--- a/spack/wdmapp/packages/coupler/package.py
+++ b/spack/wdmapp/packages/coupler/package.py
@@ -16,7 +16,7 @@ class Coupler(CMakePackage):
 
     maintainers = ['cwsmith','Damilare06','phyboyzhang']
 
-    version('0.1.0', tag='v0.1.0', preferred=True)
+    version('0.2.0', tag='v0.2.0', preferred=True)
     version('develop', branch='develop',
       git="git@github.com:SCOREC/wdmapp_coupling.git")
 

--- a/spack/wdmapp/packages/coupler/package.py
+++ b/spack/wdmapp/packages/coupler/package.py
@@ -16,7 +16,7 @@ class Coupler(CMakePackage):
 
     maintainers = ['cwsmith','Damilare06','phyboyzhang']
 
-    version('0.2.0', tag='v0.2.0', preferred=True)
+    version('0.1.1', tag='v0.1.1', preferred=True)
     version('develop', branch='develop',
       git="git@github.com:SCOREC/wdmapp_coupling.git")
 

--- a/spack/wdmapp/packages/gene/package.py
+++ b/spack/wdmapp/packages/gene/package.py
@@ -23,7 +23,7 @@ class Gene(CMakePackage, CudaPackage):
             submodules=True, submodules_delete=['python-diag'])
     version('coupling', branch='coupling',
             submodules=True, submodules_delete=['python-diag'])
-    version('passthrough', branch='rpi', git="git@github.com:Damilare06/gene.git",
+    version('externalCpl', branch='rpi',
             submodules=True, submodules_delete=['python-diag'])
 
     variant('pfunit', default=True,

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -40,9 +40,9 @@ class Wdmapp(BundlePackage):
     # variant +externalCpl
     depends_on('gene@externalCpl +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
         when='+externalCpl')
-    depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana +adios2',
+    depends_on('xgc-devel@externalCpl +coupling_core_edge_gene -cabana +adios2',
         when='+externalCpl')
-    depends_on('coupler@wdmapp-0.1.0',
+    depends_on('coupler@0.2.0',
         when='+externalCpl')
 
     # variant +xgc1_legacy

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -42,7 +42,7 @@ class Wdmapp(BundlePackage):
         when='+externalCpl')
     depends_on('xgc-devel@externalCpl +coupling_core_edge_gene -cabana +adios2',
         when='+externalCpl')
-    depends_on('coupler@0.2.0',
+    depends_on('coupler@0.1.1',
         when='+externalCpl')
 
     # variant +xgc1_legacy

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -34,8 +34,6 @@ class Wdmapp(BundlePackage):
         when='~externalCpl')
     depends_on('xgc-devel@wdmapp-0.1.0 +coupling_core_edge_gene -cabana +adios2',
         when='~externalCpl')
-    depends_on('coupler@master',
-        when='~externalCpl')
 
     # variant +externalCpl
     depends_on('gene@externalCpl +adios2 +futils +wdmapp +diag_planes perf=perfstubs',

--- a/spack/wdmapp/packages/wdmapp/package.py
+++ b/spack/wdmapp/packages/wdmapp/package.py
@@ -20,8 +20,8 @@ class Wdmapp(BundlePackage):
 
     version('0.1.0',preferred=True)
 
-    variant('passthrough', default=False,
-            description='Enable pass-through coupler')
+    variant('externalCpl', default=False,
+            description='Enable external coupler')
     variant('xgc1_legacy', default=False,
             description='Build legacy XGC1/coupling code')
     variant('tau', default=True,
@@ -31,19 +31,19 @@ class Wdmapp(BundlePackage):
 
     # normal
     depends_on('gene@wdmapp-0.1.0 +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
-        when='~passthrough')
+        when='~externalCpl')
     depends_on('xgc-devel@wdmapp-0.1.0 +coupling_core_edge_gene -cabana +adios2',
-        when='~passthrough')
+        when='~externalCpl')
     depends_on('coupler@master',
-        when='~passthrough')
+        when='~externalCpl')
 
-    # variant +passthrough
-    depends_on('gene@passthrough +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
-        when='+passthrough')
+    # variant +externalCpl
+    depends_on('gene@externalCpl +adios2 +futils +wdmapp +diag_planes perf=perfstubs',
+        when='+externalCpl')
     depends_on('xgc-devel@rpi +coupling_core_edge_gene -cabana +adios2',
-        when='+passthrough')
-    depends_on('coupler@develop',
-        when='+passthrough')
+        when='+externalCpl')
+    depends_on('coupler@wdmapp-0.1.0',
+        when='+externalCpl')
 
     # variant +xgc1_legacy
     depends_on('xgc1@master +coupling_core_edge +coupling_core_edge_field +coupling_core_edge_varpi2',
@@ -54,8 +54,8 @@ class Wdmapp(BundlePackage):
 
     # variant +effis
     depends_on('effis@0.1.0 -python -compose', when='+effis')
-    depends_on('gene@wdmapp-0.1.0 +effis', when='~passthrough +effis')
-    depends_on('xgc-devel@wdmapp-0.1.0 +effis', when='~passthrough +effis')
+    depends_on('gene@wdmapp-0.1.0 +effis', when='~externalCpl +effis')
+    depends_on('xgc-devel@wdmapp-0.1.0 +effis', when='~externaCpl +effis')
 
 
     # FIXME these are hacks to avoid Spack not finding a feasible packages on its own

--- a/spack/wdmapp/packages/xgc-devel/package.py
+++ b/spack/wdmapp/packages/xgc-devel/package.py
@@ -18,7 +18,7 @@ class XgcDevel(CMakePackage):
 
     version('wdmapp-0.1.0', tag='wdmapp-0.1.0', preferred=True)
     version('wdmapp', branch='wdmapp')
-    version('rpi', branch='rpi')
+    version('externalCpl', branch='rpi')
 
     variant('adios2', default=True,
             description="Enable ADIOS2 output")


### PR DESCRIPTION
The following script/commands will install wdmapp for running the cyclone problem with xgc-coupler-gene on summit.

```shell
#!/bin/bash -x
externalCpl=$1
[[ "$externalCpl" != "on" &&
  "$externalCpl" != "off"  ]] &&
  echo "Usage: $0 <externalCpl=on|off>" &&
  exit 1;

date=`date +%F-%H-%M`
wdmDir=$SCRATCH/wdmExtCpl_${date}
mkdir -p $wdmDir
cd $wdmDir
git clone -b v0.15.4 https://github.com/spack/spack.git
git clone -b extCplv0154 git@github.com:SCOREC/wdmapp-config.git
cd spack
export SPACK_ROOT=$PWD
source $SPACK_ROOT/share/spack/setup-env.sh
which spack # sanity check

#yaml files
mkdir $SPACK_ROOT/etc/spack/linux
cp $wdmDir/wdmapp-config/summit/spack/*.yaml $_
cd $_
mv packages.yaml packages.minimal.yaml
ln -s packages-extended.yaml packages.yaml

#add the wdmapp repo
spack repo add --scope site $wdmDir/wdmapp-config/spack/wdmapp
spack repo list # sanity check

# setup scratch space for spack
spackScratch=/gpfs/alpine/phy122/scratch/$USER/spack-stage-${date}
mkdir -p $spackScratch
(
cat <<APPEND_HEREDOC
config:
  build_stage:
   - \$tempdir/\$user/spack-stage
   - $spackScratch
   - ~/.spack/stage
APPEND_HEREDOC
) >> $SPACK_ROOT/etc/spack/config.yaml

spec="wdmapp +externalCpl"
[ $externalCpl == "off" ] && spec="wdmapp"
spack spec -I $spec
spack install $spec
```